### PR TITLE
Use Cacheable::cache_key_prefix in metrics naming.

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -183,14 +183,14 @@ where
                 Some(CachedValueState::Actual(res)) => {
                     debug!("Cached value retrieved successfully");
                     #[cfg(feature = "metrics")]
-                    CACHE_HIT_COUNTER.with_label_values(&[message, actor]).inc();
+                    CACHE_HIT_COUNTER.with_label_values(&[&message, actor]).inc();
                     Ok(res.into_inner())
                 }
                 Some(CachedValueState::Stale(res)) => {
                     debug!("Cache is stale, trying to acquire lock.");
                     #[cfg(feature = "metrics")]
                     CACHE_STALE_COUNTER
-                        .with_label_values(&[message, actor])
+                        .with_label_values(&[&message, actor])
                         .inc();
                     let lock_key = format!("lock::{}", msg.message.cache_key()?);
                     let ttl = msg.message.cache_ttl() - msg.message.cache_stale_ttl();
@@ -213,7 +213,7 @@ where
                             let cache_stale_ttl = msg.message.cache_stale_ttl();
                             #[cfg(feature = "metrics")]
                             let query_timer = CACHE_UPSTREAM_HANDLING_HISTOGRAM
-                                .with_label_values(&[message, actor])
+                                .with_label_values(&[&message, actor])
                                 .start_timer();
                             let upstream_result = msg.upstream.send(msg.message).await?;
                             #[cfg(feature = "metrics")]
@@ -244,13 +244,13 @@ where
                     debug!("Cache miss");
                     #[cfg(feature = "metrics")]
                     CACHE_MISS_COUNTER
-                        .with_label_values(&[message, actor])
+                        .with_label_values(&[&message, actor])
                         .inc();
                     let cache_stale_ttl = msg.message.cache_stale_ttl();
                     let ttl = Some(msg.message.cache_ttl());
                     #[cfg(feature = "metrics")]
                     let query_timer = CACHE_UPSTREAM_HANDLING_HISTOGRAM
-                        .with_label_values(&[message, actor])
+                        .with_label_values(&[&message, actor])
                         .start_timer();
                     let upstream_result = msg.upstream.send(msg.message).await?;
                     #[cfg(feature = "metrics")]
@@ -267,7 +267,7 @@ where
                 None => {
                     #[cfg(feature = "metrics")]
                     let query_timer = CACHE_UPSTREAM_HANDLING_HISTOGRAM
-                        .with_label_values(&[message, actor])
+                        .with_label_values(&[&message, actor])
                         .start_timer();
                     let upstream_result = msg.upstream.send(msg.message).await?;
                     #[cfg(feature = "metrics")]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -162,7 +162,7 @@ where
 
     fn handle(&mut self, msg: QueryCache<A, M>, _: &mut Self::Context) -> Self::Result {
         #[cfg(feature = "metrics")]
-        let (actor, message) = (std::any::type_name::<A>(), std::any::type_name::<M>());
+        let (actor, message) = (std::any::type_name::<A>(), msg.message.cache_key_prefix());
         let backend = self.backend.clone();
         let (enabled, cache_key) = match msg.message.cache_key() {
             Ok(value) => (self.enabled, value),

--- a/tests/test_metrics.rs
+++ b/tests/test_metrics.rs
@@ -67,13 +67,13 @@ mod tests {
         assert_eq!(
             2,
             CACHE_MISS_COUNTER
-                .with_label_values(&["test_metrics::tests::Ping", "test_metrics::tests::Upstream"])
+                .with_label_values(&["Ping", "test_metrics::tests::Upstream"])
                 .get()
         );
         assert_eq!(
             1,
             CACHE_MISS_COUNTER
-                .with_label_values(&["test_metrics::tests::Pong", "test_metrics::tests::Upstream"])
+                .with_label_values(&["Pong", "test_metrics::tests::Upstream"])
                 .get()
         );
     }


### PR DESCRIPTION
I am not sure if such change closes #18 but that what I tried to accomplish.